### PR TITLE
Make all asserts one-liners (easier to strip when neccesary)

### DIFF
--- a/003-below_zero.dfy
+++ b/003-below_zero.dfy
@@ -11,7 +11,9 @@ lemma psum_property(s: seq<int>, i: int)
     calc == {
         psum(s[..(i+1)]);
         psum(s[..(i+1)][..(i+1)-1]) + s[..(i+1)][(i+1) - 1];
-        { assert s[..(i+1)][..(i+1)-1] == s[..i]; }
+        { 
+            assert s[..(i+1)][..(i+1)-1] == s[..i];
+        }
         psum(s[..i]) + s[i];
     }
 }
@@ -28,9 +30,7 @@ method below_zero(ops: seq<int>) returns (res : bool)
             invariant balance == psum(ops[..i])
             invariant forall j : int :: 0 <= j <= i ==> psum(ops[..j]) >= 0
         {
-            assert psum(ops[..(i + 1)]) == psum(ops[..i]) + ops[i] by {
-                psum_property(ops, i);
-            }
+            assert psum(ops[..(i + 1)]) == psum(ops[..i]) + ops[i] by { psum_property(ops, i); }
             balance := balance + ops[i];
             if (balance < 0) {
                 return false;

--- a/004-mean_absolute_derivation.dfy
+++ b/004-mean_absolute_derivation.dfy
@@ -35,10 +35,7 @@ method mean_absolute_derivation(numbers: seq<real>) returns (derivation: real)
     invariant s == sum(numbers[..i])
   {
     s := s + numbers[i];
-    assert sum(numbers[..i + 1]) == sum(numbers[..i]) + numbers[i] by {
-      assert numbers[..i+1][..i] == numbers[..i];
-      sum_prop(numbers[..i + 1]);
-    }
+    assert sum(numbers[..i + 1]) == sum(numbers[..i]) + numbers[i] by { assert numbers[..i+1][..i] == numbers[..i]; sum_prop(numbers[..i + 1]); }
     i := i + 1;
   }
 
@@ -61,10 +58,7 @@ method mean_absolute_derivation(numbers: seq<real>) returns (derivation: real)
 
     pref_seq := pref_seq + [abs(numbers[i] - m)];
 
-    assert sum(pref_seq[..i + 1]) == sum(pref_seq[..i]) + pref_seq[i] by {
-      assert pref_seq[..i+1][..i] == pref_seq[..i];
-      sum_prop(pref_seq[..i + 1]);
-    }
+    assert sum(pref_seq[..i + 1]) == sum(pref_seq[..i]) + pref_seq[i] by { assert pref_seq[..i+1][..i] == pref_seq[..i]; sum_prop(pref_seq[..i + 1]); }
 
     t := t + abs(numbers[i] - m);
     i := i + 1;

--- a/008-sum_product.dfy
+++ b/008-sum_product.dfy
@@ -37,16 +37,10 @@ method sum_product(numbers: seq<int>) returns (s : int, p : int)
         invariant s == sum(numbers[..i])
         invariant p == prod(numbers[..i])
     {
-        assert sum(numbers[..i + 1]) == sum(numbers[..i]) + numbers[i] by {
-            assert numbers[..i+1][..i] == numbers[..i];
-            sum_prop(numbers[..i + 1]); 
-        }
+        assert sum(numbers[..i + 1]) == sum(numbers[..i]) + numbers[i] by { assert numbers[..i+1][..i] == numbers[..i]; sum_prop(numbers[..i + 1]); }
         s := s + numbers[i];
 
-        assert prod(numbers[..i + 1]) == prod(numbers[..i]) * numbers[i] by {
-            assert numbers[..i+1][..i] == numbers[..i];
-            prod_prop(numbers[..i + 1]); 
-        }
+        assert prod(numbers[..i + 1]) == prod(numbers[..i]) * numbers[i] by { assert numbers[..i+1][..i] == numbers[..i]; prod_prop(numbers[..i + 1]); }
         p := p * numbers[i];
 
         i := i + 1;

--- a/026-remove_duplicates.dfy
+++ b/026-remove_duplicates.dfy
@@ -51,10 +51,7 @@ method count(a: seq<int>, x: int) returns (cnt: int)
       cnt := cnt + 1;
       positions := positions + {i};
     }
-    assert count_rec(a[..i + 1], x) == count_rec(a[..i], x) + (if a[i] == x then 1 else 0) by {
-        assert a[..i+1][..i] == a[..i];
-        count_prop(a[..i + 1], x);
-    }
+    assert count_rec(a[..i + 1], x) == count_rec(a[..i], x) + (if a[i] == x then 1 else 0) by { assert a[..i+1][..i] == a[..i]; count_prop(a[..i + 1], x); }
     i := i + 1;
   }
   assert a == a[..|a|];

--- a/034-unique.dfy
+++ b/034-unique.dfy
@@ -27,12 +27,8 @@ method unique(s: seq<int>) returns (result: seq<int>)
 {
     var sorted := SortSeq(s);
     result := uniqueSorted(sorted);
-    assert forall x :: x in sorted ==> x in s by {
-        assert forall x :: x in multiset(sorted) ==> x in s;
-    }
-    assert forall x :: x in s ==> x in sorted by {
-        assert forall x :: x in multiset(s) ==> x in sorted;
-    }
+    assert forall x :: x in sorted ==> x in s by { assert forall x :: x in multiset(sorted) ==> x in s; }
+    assert forall x :: x in s ==> x in sorted by { assert forall x :: x in multiset(s) ==> x in sorted; }
 }
 
 method SortSeq(s: seq<int>) returns (sorted: seq<int>)

--- a/066-digitSum.dfy
+++ b/066-digitSum.dfy
@@ -34,10 +34,7 @@ method upper_sum(s: string) returns (res: int)
         invariant res == upper_sum_rec(s[..i])
     {
         res := res + to_int(s[i]);
-        assert upper_sum_rec(s[..i + 1]) == upper_sum_rec(s[..i]) + to_int(s[i]) by {
-            assert s[..i+1][..i] == s[..i];
-            upper_sum_rec_prop(s[..i + 1]);
-        }
+        assert upper_sum_rec(s[..i + 1]) == upper_sum_rec(s[..i]) + to_int(s[i]) by { assert s[..i+1][..i] == s[..i]; upper_sum_rec_prop(s[..i + 1]); }
         i := i + 1;
     }
     assert s == s[..|s|];

--- a/072-will_it_fly.dfy
+++ b/072-will_it_fly.dfy
@@ -26,10 +26,7 @@ method will_it_fly(s: seq<int>, w: int) returns (result: bool)
         invariant total == sum(s[..i])
     {
         total := total + s[i];
-        assert sum(s[..i + 1]) == sum(s[..i]) + s[i] by {
-            assert s[..i+1][..i] == s[..i];
-            sum_prop(s[..i + 1]);
-        }
+        assert sum(s[..i + 1]) == sum(s[..i]) + s[i] by { assert s[..i+1][..i] == s[..i]; sum_prop(s[..i + 1]); }
         i := i + 1;
     }
 

--- a/074-total_match.dfy
+++ b/074-total_match.dfy
@@ -40,10 +40,7 @@ method SumChars(list: seq<string>) returns (sum: nat)
         invariant sum == sum_chars_rec(list[..i])
     {
         sum := sum + |list[i]|;
-        assert sum_chars_rec(list[..i + 1]) == sum_chars_rec(list[..i]) + |list[i]| by {
-            assert list[..i+1][..i] == list[..i];
-            sum_prop(list[..i + 1]); 
-        }
+        assert sum_chars_rec(list[..i + 1]) == sum_chars_rec(list[..i]) + |list[i]| by { assert list[..i+1][..i] == list[..i]; sum_prop(list[..i + 1]); }
 
         i := i + 1;
     }

--- a/078-hex_key.dfy
+++ b/078-hex_key.dfy
@@ -31,12 +31,7 @@ method count_prime_hex_digits(s: seq<char>) returns (count : int)
         invariant 0 <= i <= |s|
         invariant count == count_prime_hex_digits_rec(s[..i])
     {
-        assert count_prime_hex_digits_rec(s[..i + 1]) == count_prime_hex_digits_rec(s[..i]) + (
-            if IsPrimeHexDigit(s[ i ]) then 1 else 0
-        ) by {
-            assert s[..i+1][..i] == s[..i];
-            count_prop(s[..i + 1]);
-        }
+        assert count_prime_hex_digits_rec(s[..i + 1]) == count_prime_hex_digits_rec(s[..i]) + (if IsPrimeHexDigit(s[ i ]) then 1 else 0) by { assert s[..i+1][..i] == s[..i]; count_prop(s[..i + 1]); }
         count := count + if IsPrimeHexDigit(s[i]) then 1 else 0;
         i := i + 1;
     }

--- a/085-add.dfy
+++ b/085-add.dfy
@@ -35,9 +35,7 @@ method add(v: seq<int>) returns (r : int)
             assert p[..k + 1][..k] == p[..k];
             r := r + if p[k] then v[k] else 0;
             k := k + 1;
-            assert sumc(v[..k], p[..k]) == r by {
-                sum_prop(v[..k], p[..k]);
-            }
+            assert sumc(v[..k], p[..k]) == r by { sum_prop(v[..k], p[..k]); }
         }
         assert v[..k] == v;
         assert p[..k] == p;

--- a/104-unique_digits.dfy
+++ b/104-unique_digits.dfy
@@ -53,7 +53,5 @@ method UniqueDigits(x: seq<int>) returns (result: seq<int>)
 
   assert forall e :: e in result ==> HasNoEvenDigit(e);
   assert forall e :: e in result ==> e in x;
-  assert forall e :: e in x && HasNoEvenDigit(e) ==> e in result by {
-    assert forall e :: e in unsorted ==> e in multiset(result);
-  }
+  assert forall e :: e in x && HasNoEvenDigit(e) ==> e in result by { assert forall e :: e in unsorted ==> e in multiset(result); }
 }

--- a/105-by_length.dfy
+++ b/105-by_length.dfy
@@ -16,13 +16,9 @@ method SortReverseAndName(arr: seq<int>) returns (result: seq<string>)
 
   ghost var unsorted := validNumbers;
   validNumbers := SortSeq(validNumbers);
-  assert forall j :: 0 <= j < |validNumbers| ==> 1 <= validNumbers[j] <= 9 by {
-    assert forall j :: 0 <= j < |validNumbers| ==> validNumbers[j] in multiset(unsorted);
-  }
+  assert forall j :: 0 <= j < |validNumbers| ==> 1 <= validNumbers[j] <= 9 by { assert forall j :: 0 <= j < |validNumbers| ==> validNumbers[j] in multiset(unsorted); }
   validNumbers := reverse(validNumbers);
-  assert forall j :: 0 <= j < |validNumbers| ==> 1 <= validNumbers[j] <= 9 by {
-    assert forall j :: 0 <= j < |validNumbers| ==> validNumbers[j] in multiset(unsorted);
-  }
+  assert forall j :: 0 <= j < |validNumbers| ==> 1 <= validNumbers[j] <= 9 by { assert forall j :: 0 <= j < |validNumbers| ==> validNumbers[j] in multiset(unsorted); }
 
   assert forall i, j :: 0 <= i < j < |validNumbers| ==> validNumbers[i] >= validNumbers[j];
   result := [];

--- a/120-maximum.dfy
+++ b/120-maximum.dfy
@@ -12,7 +12,7 @@ method maximum(s: seq<int>, k: int) returns (result: seq<int>)
   result := sorted[|s| - k..];
 
   // I can't make this a postcondition because it relies on an internal variable
-  assert forall i, j :: 0 <= i < |s| - k && 0 <= j < k ==> sorted[i] <= result[j]; 
+  assert forall i, j :: 0 <= i < |s| - k && 0 <= j < k ==> sorted[i] <= result[j];
 }
 
 method SortSeq(s: seq<int>) returns (sorted: seq<int>)
@@ -51,12 +51,8 @@ method SortSeq(s: seq<int>) returns (sorted: seq<int>)
     i := i + 1;
   }
 
-  assert forall i :: 0 <= i < |s| ==> exists j :: 0 <= j < |sorted| && s[i] == sorted[j] by {
-    assert forall i :: 0 <= i < |s| ==> s[i] in multiset(sorted);
-  }
+  assert forall i :: 0 <= i < |s| ==> exists j :: 0 <= j < |sorted| && s[i] == sorted[j] by { assert forall i :: 0 <= i < |s| ==> s[i] in multiset(sorted); }
   assert forall x :: x in s ==> x in sorted;
-  assert forall i :: 0 <= i < |s| ==> exists j :: 0 <= j < |sorted| && sorted[i] == s[j] by {
-    assert forall i :: 0 <= i < |s| ==> sorted[i] in multiset(s);
-  }
+  assert forall i :: 0 <= i < |s| ==> exists j :: 0 <= j < |sorted| && sorted[i] == s[j] by { assert forall i :: 0 <= i < |s| ==> sorted[i] in multiset(s); }
   assert forall x :: x in sorted ==> x in s;
 }

--- a/122-add_elements.dfy
+++ b/122-add_elements.dfy
@@ -33,10 +33,7 @@ method select_at_most_two_digits(arr: seq<int>) returns (result: seq<int>)
     if 0 <= arr[i] < 100 {
       result := result + [arr[i]];
     }
-    assert select_at_most_two_digits_rec(arr[..i + 1]) == select_at_most_two_digits_rec(arr[..i]) + if 0 <= arr[i] < 100 then [arr[i]] else [] by {
-      assert arr[..i+1][..i] == arr[..i];
-      select_prop(arr[..i + 1]);
-    }
+    assert select_at_most_two_digits_rec(arr[..i + 1]) == select_at_most_two_digits_rec(arr[..i]) + if 0 <= arr[i] < 100 then [arr[i]] else [] by { assert arr[..i+1][..i] == arr[..i]; select_prop(arr[..i + 1]); }
     i := i + 1;
   }
   assert arr[..|arr|] == arr;
@@ -69,10 +66,7 @@ method SumElementsWithAtMostTwoDigits(arr: seq<int>, k: int) returns (s: int)
     invariant s == sum(two_digits[..i])
   {
     s := s + two_digits[i];
-    assert sum(two_digits[..i + 1]) == sum(two_digits[..i]) + two_digits[i] by {
-      assert two_digits[..i+1][..i] == two_digits[..i];
-      sum_prop(two_digits[..i + 1]); 
-    }
+    assert sum(two_digits[..i + 1]) == sum(two_digits[..i]) + two_digits[i] by { assert two_digits[..i+1][..i] == two_digits[..i]; sum_prop(two_digits[..i + 1]); }
     i := i + 1;
   }
   assert two_digits[..|two_digits|] == two_digits;

--- a/151-double_the_difference.dfy
+++ b/151-double_the_difference.dfy
@@ -43,9 +43,7 @@ method double_the_difference(lst: seq<int>) returns (r : int)
             assert p[..k + 1][..k] == p[..k];
             r := r + if p[k] then v[k] else 0;
             k := k + 1;
-            assert sumc(v[..k], p[..k]) == r by {
-                sum_prop(v[..k], p[..k]);
-            }
+            assert sumc(v[..k], p[..k]) == r by { sum_prop(v[..k], p[..k]); }
         }
         assert v[..k] == v;
         assert p[..k] == p;


### PR DESCRIPTION
Make all assets fit wtihin a single line, so that they can be easily stripped while leaving the syntax correct.